### PR TITLE
Register htmlbars inline precompile on registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,10 @@
   "dependencies": {
     "babel-plugin-htmlbars-inline-precompile": "0.0.2",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "^0.7.6"
+    "ember-cli-htmlbars": "^0.7.7",
+    "ember-cli-version-checker": "^1.0.2"
   },
   "ember-addon": {
-    "after": [
-      "ember-cli-babel"
-    ],
     "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
This refactors the way how the HTMLBarsInlinePrecompilePlugin is
registered on the babel pipeline: previously the ember-cli-babel options
were hijacked and the babel plugin has been added.

Since ember-cli-babel v5.X.X registered addons under the `babel-plugin`
type are added automatically. Since ember-cli-htmlbars v0.7.7 a
`precompile` method is exported on the plugin, so there is no more need
to manually get the HTMLBarsCompiler out of bower_components.

---

This addresses #7 and closes #4 and #5.
