### PR TITLE
Provide template compiler cache key to babel plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 var HTMLBarsInlinePrecompilePlugin = require('babel-plugin-htmlbars-inline-precompile');
 
 module.exports = {
@@ -37,7 +38,11 @@ module.exports = {
     global.EmberENV = EmberENV;
 
     var Compiler = require(templateCompilerPath);
-    var PrecompileInlineHTMLBarsPlugin = HTMLBarsInlinePrecompilePlugin(Compiler.precompile); // jshint ignore:line
+    var templateCompilerFullPath = require.resolve(templateCompilerPath);
+    var templateCompilerCacheKey = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
+    var PrecompileInlineHTMLBarsPlugin = HTMLBarsInlinePrecompilePlugin(Compiler.precompile, {
+      cacheKey: templateCompilerCacheKey
+    });
 
     delete require.cache[templateCompilerPath];
     delete global.Ember;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-cli"
   ],
   "dependencies": {
-    "babel-plugin-htmlbars-inline-precompile": "0.0.5",
+    "babel-plugin-htmlbars-inline-precompile": "^0.1.0",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.0"
   },


### PR DESCRIPTION
This uses the file contents as cache key for the `babel-plugin-htmlbars-inline-precompile` plugin used.

This is based on the following PR's:

* https://github.com/babel/broccoli-babel-transpiler/pull/89
* https://github.com/pangratz/babel-plugin-htmlbars-inline-precompile/issues/15