### PR TITLE
Fix AST plugin usage with inline precompiler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "babel-plugin-htmlbars-inline-precompile": "^0.1.0",
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "^1.0.0"
+    "ember-cli-htmlbars": "^1.0.0",
+    "hash-for-dep": "^1.0.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
I plan to extract the parts that are shared between ember-cli-htmlbars and ember-cli-htmlbars-inline-precompile into a separate library (or finish the migration of this setup into ember-cli-htmlbars).  For now this fixes the immediate breakage.