### PR TITLE
Fixes init call so this works in older versions of ember-cli

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
   name: 'ember-cli-htmlbars-inline-precompile',
 
   init() {
-    this._super.init.apply(this, arguments);
+    this._super.init && this._super.init.apply(this, arguments);
 
     let checker = new VersionChecker(this);
     let hasIncorrectBabelVersion = checker.for('ember-cli-babel', 'npm').lt('6.0.0-alpha.1');


### PR DESCRIPTION
Fixes call to init for older versions of ember-cli

This follows the recommended approach mentioned on
https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L180

Fixes https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/75