### PR TITLE
Adds explicit function keyword, removing concise function syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var semver = require('semver');
 module.exports = {
   name: 'ember-cli-htmlbars-inline-precompile',
 
-  init() {
+  init: function() {
     this._super.init && this._super.init.apply(this, arguments);
 
     let babelPath = resolve.sync('ember-cli-babel/package.json', { basedir: this.parent.root });


### PR DESCRIPTION
The concise function syntax is unsupported by Node 0.1x, and causes compilation issues for older projects.