### PR TITLE
Ensure ember-template-compiler does not mutate shared config object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,11 @@ module.exports = {
     // we will also fix this in ember for future releases
     delete require.cache[templateCompilerPath];
 
-    global.EmberENV = EmberENV;
+    // do a full clone of the EmberENV (it is guaranteed to be structured
+    // cloneable) to prevent ember-template-compiler.js from mutating
+    // the shared global config
+    let clonedEmberENV = JSON.parse(JSON.stringify(EmberENV));
+    global.EmberENV = clonedEmberENV;
 
     let pluginInfo = this.astPlugins();
     let Compiler = require(templateCompilerPath);


### PR DESCRIPTION
During evaluation of `EmberENV` Ember internally mutatest the object (setting defaults and whatnot). This change prevents the mutation from modifying the actual configuration embedded into the final assets.

Related to failing tests in https://github.com/ember-cli/ember-cli/pull/7270.