### PR TITLE
Update CI to do multiple builds in the same CI run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,6 @@ sudo: false
 cache:
   yarn: true
 
-env:
-  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-source
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
@@ -35,9 +20,7 @@ install:
   - bower install
 
 script:
-  # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:each
 
 before_deploy:
   - yarn global add auto-dist-tag

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -3,28 +3,6 @@ module.exports = {
   command: 'ember test',
   scenarios: [
     {
-      name: 'ember-1.13',
-      bower: {
-        dependencies: {
-          'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -32,6 +10,21 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-8'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.12',
+      bower: {
+        dependencies: {
+          'ember': null,
+          'ember-cli-shims': null
+        }
+      },
+      npm: {
+        dependencies: {
+          'ember-source': '~2.12.0',
+          'ember-cli-shims': '^1.0.0'
         }
       }
     },
@@ -58,6 +51,7 @@ module.exports = {
       }
     },
     {
+      allowedToFail: true,
       name: 'ember-canary',
       bower: {
         dependencies: {


### PR DESCRIPTION
The prior configuration masked caching issues by always running separate Ember versions in separate processes (without a shared persistent cache).

This migrates to using `ember try:each` (instead of many CI jobs with `ember try:one`) to ensure that we are properly testing the cache invalidation logic.

Demonstrates the failure mode of https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/95.