### PR TITLE
Fix caching for parallel plugin objects

### DIFF
--- a/lib/ast-plugins.js
+++ b/lib/ast-plugins.js
@@ -33,9 +33,7 @@ module.exports = {
     global.EmberENV = clonedEmberENV;
 
     let Compiler = require(templateCompilerPath);
-    let templateCompilerFullPath = require.resolve(templateCompilerPath);
-    let templateCompilerCacheKey = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
-    let cacheKey = [templateCompilerCacheKey].concat(pluginInfo.cacheKeys.sort()).join('|');
+    let cacheKey = this.makeCacheKey(templateCompilerPath, pluginInfo);
 
     let precompileInlineHTMLBarsPlugin;
 
@@ -60,5 +58,14 @@ module.exports = {
     delete global.EmberENV;
 
     return precompileInlineHTMLBarsPlugin;
+  },
+
+  makeCacheKey(templateCompilerPath, pluginInfo, extra) {
+    require(templateCompilerPath);
+    let templateCompilerFullPath = require.resolve(templateCompilerPath);
+    let templateCompilerCacheKey = fs.readFileSync(templateCompilerFullPath, { encoding: 'utf-8' });
+    let cacheItems = [templateCompilerCacheKey, extra].concat(pluginInfo.cacheKeys.sort());
+    // extra may be undefined
+    return cacheItems.filter(Boolean).join('|');
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -217,6 +217,7 @@ describe('included()', function() {
     });
 
     it('should have plugin object', function() {
+      let expectedCacheKey = [templateCompilerContents].concat(['mock hash']).join('|');
       expect(Array.isArray(configuredPlugins[0])).to.eql(true);
       expect(configuredPlugins[0].length).to.eql(2);
       let pluginObject = configuredPlugins[0][0];
@@ -226,6 +227,9 @@ describe('included()', function() {
       expect(typeof pluginParams.precompile.baseDir).to.eql('function');
       expect(pluginParams.precompile.baseDir()).to.eql(testBaseDir());
       expect(typeof pluginParams.precompile.cacheKey).to.eql('function');
+      let cacheKey = pluginParams.precompile.cacheKey();
+      expect(cacheKey.length).to.equal(expectedCacheKey.length);
+      expect(cacheKey).to.equal(expectedCacheKey);
     });
   });
 
@@ -243,6 +247,7 @@ describe('included()', function() {
     });
 
     it('should have plugin object', function() {
+      let expectedCacheKey = [templateCompilerContents].concat(['mock hash', 'mock hash']).join('|');
       expect(Array.isArray(configuredPlugins[0])).to.eql(true);
       expect(configuredPlugins[0].length).to.eql(2);
       let pluginObject = configuredPlugins[0][0];
@@ -252,6 +257,9 @@ describe('included()', function() {
       expect(typeof pluginParams.precompile.baseDir).to.eql('function');
       expect(pluginParams.precompile.baseDir()).to.eql(testBaseDir());
       expect(typeof pluginParams.precompile.cacheKey).to.eql('function');
+      let cacheKey = pluginParams.precompile.cacheKey();
+      expect(cacheKey.length).to.equal(expectedCacheKey.length);
+      expect(cacheKey).to.equal(expectedCacheKey);
     });
   });
 });


### PR DESCRIPTION
This fixes https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/issues/95, where cache was not being invalidated across ember versions.

This adds `cacheKey()` that includes everything the normal plugin would use for the cacheKey, and the extra _parallelBabel information.