### PR TITLE
Update `ember-cli-babel` peer dependency to support Babel 7 too

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "silent-error": "^1.1.0"
   },
   "peerDependencies": {
-    "ember-cli-babel": "^6.7.1"
+    "ember-cli-babel": "^6.7.1 || ^7.0.0"
   },
   "resolutions": {
     "ember-cli-qunit/qunit": "~2.6.0",


### PR DESCRIPTION
Resolves #105 

/cc @rwjblue @wagenet 