### PR TITLE
Fix issue with '_registeredWithBabel' check

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
 
     // add the HTMLBarsInlinePrecompilePlugin to the list of plugins used by
     // the `ember-cli-babel` addon
-    if (!this._registeredWithBabel) {
+    if (!this._isBabelPluginRegistered(babelPlugins)) {
       let templateCompilerPath = this.templateCompilerPath();
       let parallelConfig = this.getParallelConfig(pluginWrappers);
       let pluginInfo = AstPlugins.setupDependentPlugins(pluginWrappers);
@@ -93,8 +93,26 @@ module.exports = {
         });
         babelPlugins.push(htmlBarsPlugin);
       }
-      this._registeredWithBabel = true;
     }
+  },
+
+  /**
+   * This function checks if 'ember-cli-htmlbars-inline-precompile' is already present in babelPlugins.
+   * The plugin object will be different for non parallel API and parallel API.
+   * For parallel api, check the `baseDir` of a plugin to see if it has current dirname
+   * For non parallel api, check the 'modulePaths' to see if it contains 'ember-cli-htmlbars-inline-precompile'
+   * @param {*} plugins
+   */
+  _isBabelPluginRegistered(plugins) {
+    return plugins.some(plugin => {
+      if (Array.isArray(plugin)) {
+        return plugin[0] === require.resolve('babel-plugin-htmlbars-inline-precompile');
+      } else if (plugin !== null && typeof plugin === 'object' && plugin._parallelBabel !== undefined) {
+        return plugin._parallelBabel.requireFile === path.resolve(__dirname, 'lib/require-from-worker');
+      } else {
+        return false;
+      }
+    });
   },
 
   _getAddonOptions() {

--- a/lib/ast-plugins.js
+++ b/lib/ast-plugins.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const HTMLBarsInlinePrecompilePlugin = require('babel-plugin-htmlbars-inline-precompile');
+const HTMLBarsInlinePrecompilePlugin = require.resolve('babel-plugin-htmlbars-inline-precompile');
 const hashForDep = require('hash-for-dep');
 const debugGenerator = require('heimdalljs-logger');
 const _logger = debugGenerator('ember-cli-htmlbars-inline-precompile');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
+    "ember-cli-lodash-subset": "^2.0.1",
     "ember-cli-preprocess-registry": "^3.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-test-loader": "^2.2.0",


### PR DESCRIPTION
**Issue:** Some addons adds `ember-cli-htmlbars-inline-precompile` multiple times in its babel options.

**Reason:** We have a check to handle this case  `this._registeredWithBabel` in index.js but the problem is that we might not always be dealing with the same `this` object. Even though the addon could be same the instance may not be same always.

**Solution** Check if the plugins already have `ember-cli-htmlbars-inline-precompile` in it before adding.