### PR TITLE
CI: Remove duplicate `node_js` key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,6 @@ script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup
   - yarn run test:node
 
-language: node_js
-node_js:
-  - "6"
-  - "8"
-  - "10"
-
 before_deploy:
   - yarn global add auto-dist-tag
   - auto-dist-tag --write


### PR DESCRIPTION
Fixes the CI config file breakage from https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/pull/120