### PR TITLE
Deprecate ember-cli-htmlbars-inline-precompiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 [![Ember Observer Score](http://emberobserver.com/badges/ember-cli-htmlbars-inline-precompile.svg)](http://emberobserver.com/addons/ember-cli-htmlbars-inline-precompile)
 [![Dependency Status](https://david-dm.org/ember-cli/ember-cli-htmlbars-inline-precompile.svg)](https://david-dm.org/ember-cli/ember-cli-htmlbars-inline-precompile)
 
+
+## **Deprecated**
+
+Usage of this project is deprecated, its functionality has been migrated into
+[ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars) directly.
+Please upgrade to `ember-cli-htmlbars@4.0.3` or higher.
+
+## Usage
+
 Precompile template strings within the tests of an Ember project via tagged
 template strings:
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const AstPlugins = require('./lib/ast-plugins');
 const VersionChecker = require('ember-cli-version-checker');
 const SilentError = require('silent-error');
 const debugGenerator = require('heimdalljs-logger');
+const semver = require('semver');
 
 const _logger = debugGenerator('ember-cli-htmlbars-inline-precompile');
 
@@ -31,9 +32,15 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    let emberCLIHtmlBars = this.project.findAddonByName('ember-cli-htmlbars');
+    let projectEmberCliHtmlbars = this.project.findAddonByName('ember-cli-htmlbars');
+    if(projectEmberCliHtmlbars && projectEmberCliHtmlbars.inlinePrecompilerRegistered) {
+      return;
+    }
 
-    if(emberCLIHtmlBars && emberCLIHtmlBars.inlinePrecompilerRegistered) {
+    let parentEmberCliHtmlbars = this.parent.addons.find(a => a.name === 'ember-cli-htmlbars');
+    if (parentEmberCliHtmlbars && semver.gt(parentEmberCliHtmlbars.pkg.version, '4.0.2')) {
+      // ember-cli-htmlbars will issue a deprecation message, but we need to
+      // ensure that we don't attempt to add the babel plugin
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-version-checker": "^3.1.3",
     "hash-for-dep": "^1.5.1",
     "heimdalljs-logger": "^0.1.9",
+    "semver": "^6.3.0",
     "silent-error": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`ember-cli-htmlbars@4.0.3` and higher emits a helpful deprecation message when it detects that `ember-cli-htmlbars-inline-precompile` is present.

This adds a deprecation notice to the `README.md`, and ensures that this addons `included` hook does nothing when using `ember-cli-htmlbars@4.0.3` or higher.

Closes #298